### PR TITLE
Fix --type param for wallet add command

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -401,7 +401,7 @@ pub enum WalletCommands {
         #[arg(short = 'n', long)]
         name: Option<String>,
         /// Wallet type (evm or solana)
-        #[arg(short = 't', long, value_enum)]
+        #[arg(short = 't', long = "type", value_enum)]
         wallet_type: Option<WalletType>,
         /// Private key to import (hex for EVM, base58 for Solana)
         #[arg(short = 'k', long)]

--- a/cli/tests/wallet_command_tests.rs
+++ b/cli/tests/wallet_command_tests.rs
@@ -205,7 +205,7 @@ fn test_wallet_create_alias_help() {
         .assert()
         .success()
         .stdout(predicate::str::contains("Create a new wallet"))
-        .stdout(predicate::str::contains("--wallet-type"))
+        .stdout(predicate::str::contains("--type"))
         .stdout(predicate::str::contains("--private-key"));
 }
 
@@ -217,7 +217,7 @@ fn test_wallet_add_help() {
         .success()
         .stdout(predicate::str::contains("Create a new wallet"))
         .stdout(predicate::str::contains("--name"))
-        .stdout(predicate::str::contains("--wallet-type"))
+        .stdout(predicate::str::contains("--type"))
         .stdout(predicate::str::contains("--private-key"));
 }
 

--- a/skills/pay-for-http-request/SKILL.md
+++ b/skills/pay-for-http-request/SKILL.md
@@ -118,7 +118,7 @@ purl wallet <COMMAND>
 | Option | Description |
 |--------|-------------|
 | `-n, --name <NAME>` | Name for the wallet |
-| `-t, --wallet-type <TYPE>` | Wallet type: evm or solana |
+| `-t, --type <TYPE>` | Wallet type: evm or solana |
 | `-k, --private-key <KEY>` | Private key to import (hex for EVM, base58 for Solana) |
 
 ## Config Commands


### PR DESCRIPTION
Aligns the actual option as documented `--type <evm/solana>` option on wallet commands. Previously it was documented as `--type` but really accepted `--wallet-type`.

**Before (--type not found)**
<img width="412" height="95" alt="Screenshot 2026-02-27 at 11 49 02 AM" src="https://github.com/user-attachments/assets/83f8ae92-1474-4686-9915-a7bf9e85cc75" />

... despite being documented as --type
<img width="541" height="80" alt="Screenshot 2026-02-27 at 11 54 32 AM" src="https://github.com/user-attachments/assets/78d89b8a-676c-48a9-817f-cdd6d00180a1" />

**After (standardize on --type)**

This command no longer fails, taking you to the next step in wallet addition.

<img width="538" height="38" alt="Screenshot 2026-02-27 at 11 49 11 AM" src="https://github.com/user-attachments/assets/56a983e9-6234-45e6-8bdd-e0cd1c782c2e" />
